### PR TITLE
Update create column and modify column

### DIFF
--- a/src/mcp_server_grist/tools/administration.py
+++ b/src/mcp_server_grist/tools/administration.py
@@ -728,19 +728,21 @@ async def create_column(
             "columns": [
                 {
                     "id": column_id,
-                    "type": column_type
+                    "fields":{
+                        "type": column_type
+                    }
                 }
             ]
         }
         
         # Ajouter les champs optionnels s'ils sont fournis
         if label:
-            column_data["columns"][0]["label"] = label
+            column_data["columns"][0]["fields"]["label"] = label
         if formula:
-            column_data["columns"][0]["formula"] = formula
-            column_data["columns"][0]["isFormula"] = True
+            column_data["columns"][0]["fields"]["formula"] = formula
+            column_data["columns"][0]["fields"]["isFormula"] = True
         if widget_options:
-            column_data["columns"][0]["widgetOptions"] = widget_options
+            column_data["columns"][0]["fields"]["widgetOptions"] = widget_options
         
         result = await client.create_columns(doc_id, table_id, column_data)
         
@@ -800,7 +802,8 @@ async def modify_column(
         column_data = {
             "columns": [
                 {
-                    "id": column_id
+                    "id": column_id,
+                    "fields": {} 
                 }
             ]
         }
@@ -809,14 +812,14 @@ async def modify_column(
         if new_column_id:
             column_data["columns"][0]["newId"] = new_column_id
         if column_type:
-            column_data["columns"][0]["type"] = column_type
+            column_data["columns"][0]["fields"]["type"] = column_type
         if label:
-            column_data["columns"][0]["label"] = label
+            column_data["columns"][0]["fields"]["label"] = label
         if formula is not None:  # Permettre de vider la formule avec une chaîne vide
-            column_data["columns"][0]["formula"] = formula
-            column_data["columns"][0]["isFormula"] = bool(formula)
+            column_data["columns"][0]["fields"]["formula"] = formula
+            column_data["columns"][0]["fields"]["isFormula"] = bool(formula)
         if widget_options:
-            column_data["columns"][0]["widgetOptions"] = widget_options
+            column_data["columns"][0]["fields"]["widgetOptions"] = widget_options
         
         await client.modify_columns(doc_id, table_id, column_data)
         


### PR DESCRIPTION
**Created with Claude Desktop"

# Pull Request: Fix Column Modification API Payload Structure

## Summary

This PR fixes a critical bug in the `modify_column` and `create_column` tools that prevented them from working correctly with the Grist API. The tools were sending an incorrect payload structure, causing all column modification and creation requests to fail with a 400 error.

## Problem Description

### Current Behavior

When attempting to modify or create columns using the MCP server tools, the API consistently returns:

```json
{
  "error": "Invalid payload",
  "details": {
    "userError": "Error: body.columns[0] is not a RecordWithStringId; body.columns[0].fields is missing"
  }
}
```

### Root Cause

The tools were constructing the payload incorrectly by placing column properties directly in the column object instead of nesting them within a `fields` object, as required by the [Grist REST API specification](https://support.getgrist.com/api/#tag/docs/paths/~1docs~1{docId}~1tables~1{tableId}~1columns/patch).

**Incorrect Structure (Current):**
```json
{
  "columns": [{
    "id": "column_name",
    "type": "Numeric",
    "label": "Label",
    "formula": "...",
    "isFormula": true
  }]
}
```

**Correct Structure (Required by API):**
```json
{
  "columns": [{
    "id": "column_name",
    "fields": {
      "type": "Numeric",
      "label": "Label",
      "formula": "...",
      "isFormula": true
    }
  }]
}
```

## Changes Made

### Files Modified

- `src/mcp_server_grist/tools/administration.py`

### Detailed Changes

#### 1. `modify_column` function (lines 800-819)

**Before:**
```python
column_data = {
    "columns": [
        {
            "id": column_id
        }
    ]
}

# Fields added directly to column object
if column_type:
    column_data["columns"][0]["type"] = column_type
if label:
    column_data["columns"][0]["label"] = label
if formula is not None:
    column_data["columns"][0]["formula"] = formula
    column_data["columns"][0]["isFormula"] = bool(formula)
```

**After:**
```python
column_data = {
    "columns": [
        {
            "id": column_id,
            "fields": {}  # Added fields object
        }
    ]
}

# Fields added within fields object
if column_type:
    column_data["columns"][0]["fields"]["type"] = column_type
if label:
    column_data["columns"][0]["fields"]["label"] = label
if formula is not None:
    column_data["columns"][0]["fields"]["formula"] = formula
    column_data["columns"][0]["fields"]["isFormula"] = bool(formula)
```

**Note:** The `newId` field (for renaming columns) correctly remains outside the `fields` object as per API specification.

#### 2. `create_column` function (lines 727-743)

**Before:**
```python
column_data = {
    "columns": [
        {
            "id": column_id,
            "type": column_type
        }
    ]
}

if label:
    column_data["columns"][0]["label"] = label
if formula:
    column_data["columns"][0]["formula"] = formula
    column_data["columns"][0]["isFormula"] = True
```

**After:**
```python
column_data = {
    "columns": [
        {
            "id": column_id,
            "fields": {
                "type": column_type
            }
        }
    ]
}

if label:
    column_data["columns"][0]["fields"]["label"] = label
if formula:
    column_data["columns"][0]["fields"]["formula"] = formula
    column_data["columns"][0]["fields"]["isFormula"] = True
```

## Testing

### Test Case 1: Modify Formula Column

```python
result = await modify_column(
    doc_id="test_doc_id",
    table_id="Budgets",
    column_id="actual_amount",
    formula="sum(Transactions.lookupRecords(category_id=$category_id).amount)"
)

# Expected: {"success": True, "message": "..."}
# Before fix: {"success": False, "message": "Error: body.columns[0].fields is missing"}
```

### Test Case 2: Create Formula Column

```python
result = await create_column(
    doc_id="test_doc_id",
    table_id="TestTable",
    column_id="total",
    column_type="Numeric",
    label="Total Amount",
    formula="$price * $quantity"
)

# Expected: {"success": True, "message": "...", "column": {...}}
# Before fix: 400 error from API
```

### Test Case 3: Rename Column with Property Changes

```python
result = await modify_column(
    doc_id="test_doc_id",
    table_id="TestTable",
    column_id="old_name",
    new_column_id="new_name",
    column_type="Numeric",
    label="New Label"
)

# Expected: Column renamed and properties updated
# newId should be outside fields, other properties inside
```

### Test Case 4: Modify Only Label (Display Name)

```python
result = await modify_column(
    doc_id="test_doc_id",
    table_id="TestTable",
    column_id="column_name",
    label="New Display Name"
)

# Expected: Only display label changed, column ID preserved
```

## API Compliance

This fix ensures full compliance with the [Grist REST API specification](https://support.getgrist.com/api/):

### Endpoint: `PATCH /docs/{docId}/tables/{tableId}/columns`

**Request Body Schema:**
```json
{
  "columns": [
    {
      "id": "string",           // Column identifier (outside fields)
      "newId": "string",         // Optional: rename column (outside fields)
      "fields": {                // Property container (required)
        "type": "string",
        "label": "string",
        "formula": "string",
        "isFormula": boolean,
        "widgetOptions": "string"
      }
    }
  ]
}
```

**Key Points:**
- `id` and `newId` remain at the column object level
- All column properties must be nested within `fields`
- The `fields` object is required, even if empty

## Impact Assessment

### Breaking Changes
None. This is a bug fix that makes the tools work as originally intended.

### Affected Functionality
- ✅ `modify_column`: Now works correctly
- ✅ `create_column`: Now works correctly
- ✅ Column renaming: Works correctly with property changes
- ✅ Formula modification: Works correctly
- ✅ Type changes: Work correctly

### Benefits
1. **Column modification now functional**: Users can update column properties via the MCP server
2. **Column creation now functional**: Users can create columns with formulas programmatically
3. **API compliance**: Payload structure matches Grist API specification
4. **No breaking changes**: The tool interface remains unchanged

## Checklist

- [x] Code follows the project's style guidelines
- [x] Changes tested with real Grist API
- [x] All affected functions updated (`modify_column` and `create_column`)
- [x] No breaking changes to tool interface
- [x] API payload structure matches official Grist documentation
- [x] Error handling preserved
- [x] Logging statements unchanged

## Related Documentation

- [Grist REST API Reference - Modify Columns](https://support.getgrist.com/api/#tag/docs/paths/~1docs~1{docId}~1tables~1{tableId}~1columns/patch)
- [Grist REST API Reference - Add Columns](https://support.getgrist.com/api/#tag/docs/paths/~1docs~1{docId}~1tables~1{tableId}~1columns/post)
- [Grist Columns & Types Documentation](https://support.getgrist.com/col-types/)

## Additional Notes

### Why This Bug Existed

The error occurred because the tool was constructing payloads based on an incorrect understanding of the API structure. The Grist API requires all column properties (except `id` and `newId`) to be nested within a `fields` object, which is a common pattern in REST APIs to separate identifiers from mutable properties.

### Column Renaming Behavior

When using `new_column_id`, note that:
- All formulas referencing `$old_name` in other columns will need to be updated manually
- The column's data is preserved
- References in other tables need to be updated
- It's recommended to update dependent formulas immediately after renaming

### Backward Compatibility

This fix maintains complete backward compatibility:
- Tool signatures unchanged
- Return values unchanged
- Error handling unchanged
- Only internal payload construction modified

## Example Usage After Fix

```python
# Modify a formula column
await modify_column(
    doc_id="abc123",
    table_id="Budgets",
    column_id="actual_amount",
    formula="sum(Transactions.lookupRecords(category_id=$category_id).amount)"
)

# Create a new formula column
await create_column(
    doc_id="abc123",
    table_id="Budgets",
    column_id="variance",
    column_type="Numeric",
    label="Budget Variance",
    formula="$planned_amount - $actual_amount"
)

# Rename and modify simultaneously
await modify_column(
    doc_id="abc123",
    table_id="Budgets",
    column_id="old_name",
    new_column_id="new_name",
    column_type="Numeric",
    label="Better Name"
)
```

## Screenshots/Evidence

**Before Fix - API Error:**
```json
{
  "success": false,
  "message": "Erreur lors de la modification de la colonne: HTTP error: 400 - {\"error\":\"Invalid payload\",\"details\":{\"userError\":\"Error: body.columns[0] is not a RecordWithStringId; body.columns[0].fields is missing\"}}"
}
```

**After Fix - Success:**
```json
{
  "success": true,
  "message": "Colonne 'actual_amount' modifiée avec succès"
}
```

## References

- Repository: https://github.com/nic01asFr/mcp-server-grist
- API Documentation: https://support.getgrist.com/api/
- Related Issue: (if applicable, add issue number)

---

**Reviewers:** Please verify the payload structure matches the API specification and test with actual Grist instances.