### PR TITLE
Fix ctx parameter to be properly injected by FastMCP

### DIFF
--- a/src/mcp_server_grist/client.py
+++ b/src/mcp_server_grist/client.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import httpx
 from dotenv import load_dotenv
+from fastmcp import Context
 
 from .models import GristColumn, GristDocument, GristOrg, GristRecord, GristTable, GristWorkspace
 from .version import __version__
@@ -712,7 +713,7 @@ class GristClient:
             return {"valid": False, "error": f"Could not validate formula: {str(e)}"}
 
 
-def get_client(ctx=None) -> GristClient:
+def get_client(ctx: Context = None) -> GristClient:
     """
     Obtient un client Grist configuré.
     

--- a/src/mcp_server_grist/tools/access.py
+++ b/src/mcp_server_grist/tools/access.py
@@ -8,6 +8,8 @@ aux organisations, espaces de travail et documents Grist.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 from ..client import get_client
 
 # Configurer le logger
@@ -37,8 +39,8 @@ def register_access_tools(mcp_server):
 # --- Organisation Access ---
 
 async def list_organization_access(
-    org_id: Union[int, str], 
-    ctx=None
+    org_id: Union[int, str],
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Liste les utilisateurs ayant accès à une organisation.
@@ -78,10 +80,10 @@ async def list_organization_access(
 
 
 async def modify_organization_access(
-    org_id: Union[int, str], 
+    org_id: Union[int, str],
     user_email: str,
     access_level: str,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie l'accès d'un utilisateur à une organisation.
@@ -138,8 +140,8 @@ async def modify_organization_access(
 # --- Workspace Access ---
 
 async def list_workspace_access(
-    workspace_id: int, 
-    ctx=None
+    workspace_id: int,
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Liste les utilisateurs ayant accès à un espace de travail.
@@ -179,10 +181,10 @@ async def list_workspace_access(
 
 
 async def modify_workspace_access(
-    workspace_id: int, 
+    workspace_id: int,
     user_email: str,
     access_level: str,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie l'accès d'un utilisateur à un espace de travail.
@@ -239,8 +241,8 @@ async def modify_workspace_access(
 # --- Document Access ---
 
 async def list_document_access(
-    doc_id: str, 
-    ctx=None
+    doc_id: str,
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Liste les utilisateurs ayant accès à un document.
@@ -280,10 +282,10 @@ async def list_document_access(
 
 
 async def modify_document_access(
-    doc_id: str, 
+    doc_id: str,
     user_email: str,
     access_level: str,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie l'accès d'un utilisateur à un document.

--- a/src/mcp_server_grist/tools/administration.py
+++ b/src/mcp_server_grist/tools/administration.py
@@ -8,6 +8,8 @@ de Grist: création et modification d'objets, gestion des accès.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 from ..client import get_client
 
 # Configurer le logger
@@ -51,9 +53,9 @@ def register_admin_tools(mcp_server):
 # --- Organisation Management ---
 
 async def modify_organization(
-    org_id: Union[int, str], 
+    org_id: Union[int, str],
     name: Optional[str] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie les propriétés d'une organisation.
@@ -103,8 +105,8 @@ async def modify_organization(
 
 
 async def delete_organization(
-    org_id: Union[int, str], 
-    ctx=None
+    org_id: Union[int, str],
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Supprime une organisation.
@@ -146,9 +148,9 @@ async def delete_organization(
 # --- Workspace Management ---
 
 async def create_workspace(
-    org_id: Union[int, str], 
+    org_id: Union[int, str],
     name: str,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Crée un nouvel espace de travail dans une organisation.
@@ -195,9 +197,9 @@ async def create_workspace(
 
 
 async def modify_workspace(
-    workspace_id: int, 
+    workspace_id: int,
     name: Optional[str] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie les propriétés d'un espace de travail.
@@ -247,8 +249,8 @@ async def modify_workspace(
 
 
 async def delete_workspace(
-    workspace_id: int, 
-    ctx=None
+    workspace_id: int,
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Supprime un espace de travail.
@@ -290,9 +292,9 @@ async def delete_workspace(
 # --- Document Management ---
 
 async def create_document(
-    workspace_id: int, 
+    workspace_id: int,
     name: str,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Crée un nouveau document dans un espace de travail.
@@ -339,10 +341,10 @@ async def create_document(
 
 
 async def modify_document(
-    doc_id: str, 
+    doc_id: str,
     name: Optional[str] = None,
     is_pinned: Optional[bool] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie les propriétés d'un document.
@@ -395,8 +397,8 @@ async def modify_document(
 
 
 async def delete_document(
-    doc_id: str, 
-    ctx=None
+    doc_id: str,
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Supprime un document.
@@ -436,9 +438,9 @@ async def delete_document(
 
 
 async def move_document(
-    doc_id: str, 
+    doc_id: str,
     target_workspace_id: int,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Déplace un document vers un autre espace de travail.
@@ -479,8 +481,8 @@ async def move_document(
 
 
 async def force_reload_document(
-    doc_id: str, 
-    ctx=None
+    doc_id: str,
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Force le rechargement d'un document.
@@ -518,9 +520,9 @@ async def force_reload_document(
 
 
 async def delete_document_history(
-    doc_id: str, 
+    doc_id: str,
     keep: int = 1000,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Supprime l'historique d'un document, ne conservant que les dernières actions.
@@ -561,10 +563,10 @@ async def delete_document_history(
 # --- Table Management ---
 
 async def create_table(
-    doc_id: str, 
+    doc_id: str,
     table_id: str,
     columns: Optional[List[Dict[str, Any]]] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Crée une nouvelle table dans un document.
@@ -621,10 +623,10 @@ async def create_table(
 
 
 async def modify_table(
-    doc_id: str, 
+    doc_id: str,
     table_id: str,
     new_table_id: Optional[str] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie les propriétés d'une table.
@@ -682,14 +684,14 @@ async def modify_table(
 # --- Column Management ---
 
 async def create_column(
-    doc_id: str, 
+    doc_id: str,
     table_id: str,
     column_id: str,
     column_type: str = "Text",
     label: Optional[str] = None,
     formula: Optional[str] = None,
     widget_options: Optional[Dict[str, Any]] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Crée une nouvelle colonne dans une table.
@@ -760,7 +762,7 @@ async def create_column(
 
 
 async def modify_column(
-    doc_id: str, 
+    doc_id: str,
     table_id: str,
     column_id: str,
     new_column_id: Optional[str] = None,
@@ -768,7 +770,7 @@ async def modify_column(
     label: Optional[str] = None,
     formula: Optional[str] = None,
     widget_options: Optional[Dict[str, Any]] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie les propriétés d'une colonne.
@@ -840,10 +842,10 @@ async def modify_column(
 
 
 async def delete_column(
-    doc_id: str, 
+    doc_id: str,
     table_id: str,
     column_id: str,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Supprime une colonne d'une table.

--- a/src/mcp_server_grist/tools/attachments.py
+++ b/src/mcp_server_grist/tools/attachments.py
@@ -8,6 +8,8 @@ dans les documents Grist: liste, téléchargement, téléversement.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 from ..client import get_client
 
 # Configurer le logger
@@ -31,7 +33,7 @@ async def list_attachments(
     doc_id: str,
     sort: Optional[str] = None,
     limit: Optional[int] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Liste les pièces jointes d'un document Grist.
@@ -77,7 +79,7 @@ async def list_attachments(
 async def get_attachment_info(
     doc_id: str,
     attachment_id: int,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Obtient les métadonnées d'une pièce jointe.
@@ -120,7 +122,7 @@ async def get_attachment_info(
 async def download_attachment(
     doc_id: str,
     attachment_id: int,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Télécharge le contenu d'une pièce jointe.
@@ -180,7 +182,7 @@ async def upload_attachment(
     filename: str,
     content_base64: str,
     content_type: str = "application/octet-stream",
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Téléverse une pièce jointe dans un document Grist.

--- a/src/mcp_server_grist/tools/export.py
+++ b/src/mcp_server_grist/tools/export.py
@@ -9,6 +9,8 @@ import base64
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 from ..client import get_client
 
 # Configurer le logger
@@ -31,7 +33,7 @@ async def download_document_sqlite(
     doc_id: str,
     nohistory: bool = False,
     template: bool = False,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Télécharge un document Grist au format SQLite.
@@ -81,7 +83,7 @@ async def download_document_sqlite(
 async def download_document_excel(
     doc_id: str,
     header: str = "label",
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Télécharge un document Grist au format Excel.
@@ -137,7 +139,7 @@ async def download_table_csv(
     doc_id: str,
     table_id: str,
     header: str = "label",
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Télécharge une table Grist au format CSV.

--- a/src/mcp_server_grist/tools/navigation.py
+++ b/src/mcp_server_grist/tools/navigation.py
@@ -8,6 +8,8 @@ organisations, espaces de travail, documents, tables, colonnes et enregistrement
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 from ..client import get_client
 from ..models import MCP_Response
 
@@ -34,7 +36,7 @@ def register_navigation_tools(mcp_server):
     mcp_server.tool()(get_table_schema)
 
 
-async def list_organizations(ctx) -> Dict[str, Any]:
+async def list_organizations(ctx: Context) -> Dict[str, Any]:
     """
     Liste toutes les organisations Grist accessibles.
     
@@ -78,7 +80,7 @@ async def list_organizations(ctx) -> Dict[str, Any]:
         }
 
 
-async def describe_organization(org_id: Union[int, str], ctx) -> Dict[str, Any]:
+async def describe_organization(org_id: Union[int, str], ctx: Context) -> Dict[str, Any]:
     """
     Obtient des informations détaillées sur une organisation spécifique.
     
@@ -123,7 +125,7 @@ async def describe_organization(org_id: Union[int, str], ctx) -> Dict[str, Any]:
         }
 
 
-async def list_workspaces(org_id: Union[int, str], ctx) -> Dict[str, Any]:
+async def list_workspaces(org_id: Union[int, str], ctx: Context) -> Dict[str, Any]:
     """
     Liste tous les espaces de travail dans une organisation Grist.
     
@@ -176,7 +178,7 @@ async def list_workspaces(org_id: Union[int, str], ctx) -> Dict[str, Any]:
         }
 
 
-async def describe_workspace(workspace_id: int, ctx) -> Dict[str, Any]:
+async def describe_workspace(workspace_id: int, ctx: Context) -> Dict[str, Any]:
     """
     Obtient des informations détaillées sur un espace de travail spécifique.
     
@@ -222,7 +224,7 @@ async def describe_workspace(workspace_id: int, ctx) -> Dict[str, Any]:
         }
 
 
-async def list_documents(workspace_id: int, ctx) -> Dict[str, Any]:
+async def list_documents(workspace_id: int, ctx: Context) -> Dict[str, Any]:
     """
     Liste tous les documents dans un espace de travail Grist.
     
@@ -275,7 +277,7 @@ async def list_documents(workspace_id: int, ctx) -> Dict[str, Any]:
         }
 
 
-async def describe_document(doc_id: str, ctx) -> Dict[str, Any]:
+async def describe_document(doc_id: str, ctx: Context) -> Dict[str, Any]:
     """
     Obtient des informations détaillées sur un document spécifique.
     
@@ -320,7 +322,7 @@ async def describe_document(doc_id: str, ctx) -> Dict[str, Any]:
         }
 
 
-async def list_tables(doc_id: str, ctx) -> Dict[str, Any]:
+async def list_tables(doc_id: str, ctx: Context) -> Dict[str, Any]:
     """
     Liste toutes les tables dans un document Grist.
     
@@ -372,7 +374,7 @@ async def list_tables(doc_id: str, ctx) -> Dict[str, Any]:
         }
 
 
-async def list_columns(doc_id: str, table_id: str, ctx) -> Dict[str, Any]:
+async def list_columns(doc_id: str, table_id: str, ctx: Context) -> Dict[str, Any]:
     """
     Liste toutes les colonnes dans une table Grist.
     
@@ -426,11 +428,11 @@ async def list_columns(doc_id: str, table_id: str, ctx) -> Dict[str, Any]:
 
 
 async def list_records(
-    doc_id: str, 
-    table_id: str, 
+    doc_id: str,
+    table_id: str,
     sort: Optional[str] = None,
     limit: Optional[int] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Liste les enregistrements dans une table Grist avec tri et limitation optionnels.
@@ -493,7 +495,7 @@ async def list_records(
         }
 
 
-async def get_table_schema(doc_id: str, table_id: str, ctx) -> Dict[str, Any]:
+async def get_table_schema(doc_id: str, table_id: str, ctx: Context) -> Dict[str, Any]:
     """
     Obtient le schéma détaillé d'une table Grist.
     

--- a/src/mcp_server_grist/tools/queries.py
+++ b/src/mcp_server_grist/tools/queries.py
@@ -9,6 +9,8 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 from ..client import get_client
 
 # Configurer le logger
@@ -34,7 +36,7 @@ async def filter_sql_query(
     where_conditions: Optional[Dict[str, Any]] = None,
     order_by: Optional[str] = None,
     limit: Optional[int] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Exécute une requête SQL de filtrage sur une table Grist.
@@ -130,7 +132,7 @@ async def execute_sql_query(
     sql_query: str,
     parameters: Optional[List[Any]] = None,
     timeout_ms: Optional[int] = 1000,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Exécute une requête SQL personnalisée sur un document Grist.

--- a/src/mcp_server_grist/tools/records.py
+++ b/src/mcp_server_grist/tools/records.py
@@ -8,6 +8,8 @@ dans les tables Grist: ajout, mise à jour et suppression.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 from ..client import get_client
 
 # Configurer le logger
@@ -29,10 +31,10 @@ def register_record_tools(mcp_server):
 
 
 async def add_grist_records(
-    doc_id: str, 
-    table_id: str, 
-    records: List[Dict[str, Any]], 
-    ctx=None
+    doc_id: str,
+    table_id: str,
+    records: List[Dict[str, Any]],
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Ajoute des enregistrements à une table Grist.
@@ -80,10 +82,10 @@ async def add_grist_records(
 
 
 async def add_grist_records_safe(
-    doc_id: str, 
-    table_id: str, 
-    records: List[Dict[str, Any]], 
-    ctx=None
+    doc_id: str,
+    table_id: str,
+    records: List[Dict[str, Any]],
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Ajoute des enregistrements avec validation préalable de la structure.
@@ -167,10 +169,10 @@ async def add_grist_records_safe(
 
 
 async def update_grist_records(
-    doc_id: str, 
-    table_id: str, 
-    records: List[Dict[str, Any]], 
-    ctx=None
+    doc_id: str,
+    table_id: str,
+    records: List[Dict[str, Any]],
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Met à jour des enregistrements existants dans une table Grist.
@@ -229,10 +231,10 @@ async def update_grist_records(
 
 
 async def delete_grist_records(
-    doc_id: str, 
-    table_id: str, 
-    record_ids: List[int], 
-    ctx=None
+    doc_id: str,
+    table_id: str,
+    record_ids: List[int],
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Supprime des enregistrements d'une table Grist.

--- a/src/mcp_server_grist/tools/webhooks.py
+++ b/src/mcp_server_grist/tools/webhooks.py
@@ -8,6 +8,8 @@ dans les documents Grist: liste, création, modification, suppression.
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Context
+
 from ..client import get_client
 
 # Configurer le logger
@@ -28,7 +30,7 @@ def register_webhook_tools(mcp_server):
     mcp_server.tool()(clear_webhook_queue)
 
 
-async def list_webhooks(doc_id: str, ctx=None) -> Dict[str, Any]:
+async def list_webhooks(doc_id: str, ctx: Context = None) -> Dict[str, Any]:
     """
     Liste les webhooks d'un document Grist.
     
@@ -74,7 +76,7 @@ async def create_webhook(
     table_id: Optional[str] = None,
     event_types: Optional[List[str]] = None,
     memo: Optional[str] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Crée un webhook pour un document Grist.
@@ -160,7 +162,7 @@ async def modify_webhook(
     event_types: Optional[List[str]] = None,
     memo: Optional[str] = None,
     active: Optional[bool] = None,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Modifie un webhook existant.
@@ -242,7 +244,7 @@ async def modify_webhook(
 async def delete_webhook(
     doc_id: str,
     webhook_id: str,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Supprime un webhook.
@@ -283,7 +285,7 @@ async def delete_webhook(
 
 async def clear_webhook_queue(
     doc_id: str,
-    ctx=None
+    ctx: Context = None
 ) -> Dict[str, Any]:
     """
     Vide la file d'attente des webhooks pour un document.


### PR DESCRIPTION
The ctx parameter was exposed as a required/optional user parameter in the MCP tool schema, which is not standard MCP protocol behavior.

Changes:
- Add Context type annotation from fastmcp to all tool functions
- FastMCP now automatically injects the context and excludes it from the MCP schema exposed to clients
- Clients no longer need to pass ctx=null when calling tools

This follows FastMCP's documented pattern for context injection: https://gofastmcp.com/servers/context